### PR TITLE
Small pour detection

### DIFF
--- a/kegbot/pycore/flow.py
+++ b/kegbot/pycore/flow.py
@@ -35,6 +35,7 @@ class Flow:
     self._end_time = when
     self._last_log_time = None
     self._total_ticks = 0L
+    self._volume_ml = None 
 
   def __str__(self):
     return '<Flow 0x%08x: meter_name=%s ticks=%s username=%s max_idle=%s>' % (self._flow_id,
@@ -53,14 +54,17 @@ class Flow:
     event.start_time = self._start_time
     event.last_activity_time = self._end_time
     event.ticks = self.GetTicks()
+    event.volume_ml = self.GetVolumeMl()
 
     return event
 
-  def AddTicks(self, amount, when=None):
+  def AddTicks(self, amount, when=None, tap=None):
     self._total_ticks += amount
     if when is None:
       when = datetime.datetime.now()
     self._end_time = when
+    if tap is not None:
+        self._volume_ml = tap.TicksToMilliliters(self._total_ticks)
 
   def GetId(self):
     return self._flow_id
@@ -73,6 +77,9 @@ class Flow:
 
   def GetTicks(self):
     return self._total_ticks
+
+  def GetVolumeMl(self):
+    return self._volume_ml
 
   def GetUsername(self):
     return self._bound_username

--- a/kegbot/pycore/kbevent.py
+++ b/kegbot/pycore/kbevent.py
@@ -85,6 +85,7 @@ class FlowUpdate(Event):
   start_time = EventField()
   last_activity_time = EventField()
   ticks = EventField()
+  volume_ml = EventField()
 
 class DrinkCreatedEvent(Event):
   flow_id = EventField()


### PR DESCRIPTION
Small pour detection was present in kegbot-pycore until commit 7711c88

https://github.com/Kegbot/kegbot-pycore/commit/7711c889428b96c6ad44e293028377a38241c15f#diff-93c7270b970dd3359f27e37b343aa6c7L384

This pull request will add back in the small pour detection. The goal of commit 7711c88 was to decouple flows from taps. Sadly to add back in small pour detection I needed to pass a Tap object into the AddTicks method on the Flow object. However if no Tap object is passed, it will simply not do minimum flow verification.
