### PR TITLE
Fix issue with relay activation

### DIFF
--- a/kegbot/pycore/common_defs.py
+++ b/kegbot/pycore/common_defs.py
@@ -21,7 +21,7 @@
 ### Drink-related constants
 
 # Don't record teeny drinks
-MIN_VOLUME_TO_RECORD = 10
+MIN_VOLUME_TO_RECORD = 35
 
 # The maximum difference between consecutive meter readings that is considered
 # valid.

--- a/kegbot/pycore/kbevent.py
+++ b/kegbot/pycore/kbevent.py
@@ -132,6 +132,9 @@ class SetRelayOutputEvent(Event):
   output_name = EventField()
   output_mode = EventField()
 
+class UserAuthenticatedEvent(Event):
+  username = EventField()
+  
 class SyncEvent(Event):
   data = EventField()
 

--- a/kegbot/pycore/kegnet.py
+++ b/kegbot/pycore/kegnet.py
@@ -109,6 +109,11 @@ class KegnetClient(object):
     message.token_value = token_value
     message.status = message.TokenState.REMOVED
     return self.send_message(message)
+	  
+  def SendUserAuthenticated(self, username):
+    message = kbevent.UserAuthenticatedEvent()
+    message.username = username
+    return self.send_message(message)
 
   def Listen(self):
     while True:

--- a/kegbot/pycore/kegnet.py
+++ b/kegbot/pycore/kegnet.py
@@ -115,6 +115,9 @@ class KegnetClient(object):
     message.username = username
     return self.send_message(message)
 
+  def SendRelayEvent(self, event):
+    return self.send_message(event)
+
   def Listen(self):
     while True:
       try:

--- a/kegbot/pycore/manager.py
+++ b/kegbot/pycore/manager.py
@@ -284,6 +284,10 @@ class FlowManager(Manager):
   def _PublishRelayEvent(self, flow, enable=True):
     self._logger.debug('Publishing relay event: flow=%s, enable=%s' % (flow,
         enable))
+			
+    client = kegnet.KegnetClient()
+    client.SendUserAuthenticated(flow.GetUsername())
+		
     tap = self._tap_manager.GetTap(flow.GetMeterName())
     if not tap:
       # Unknown meter; don't attempt to enable any relays for it

--- a/kegbot/pycore/manager.py
+++ b/kegbot/pycore/manager.py
@@ -77,6 +77,7 @@ class Manager(object):
 
   def _PublishEvent(self, event):
     """Convenience alias for EventHub.PublishEvent"""
+    self._logger.debug('Publishing event %s' % event)
     self._event_hub.PublishEvent(event)
 
 
@@ -285,6 +286,8 @@ class FlowManager(Manager):
     self._logger.debug('Publishing relay event: flow=%s, enable=%s' % (flow,
         enable))
 				
+    client = kegnet.KegnetClient()
+
     tap = self._tap_manager.GetTap(flow.GetMeterName())
     if not tap:
       # Unknown meter; don't attempt to enable any relays for it
@@ -303,6 +306,7 @@ class FlowManager(Manager):
       mode = kbevent.SetRelayOutputEvent.Mode.DISABLED
     ev = kbevent.SetRelayOutputEvent(output_name=relay, output_mode=mode)
     self._PublishEvent(ev)
+    client.SendRelayEvent(ev)
 
   @EventHandler(kbevent.FlowRequest)
   def _HandleFlowRequestEvent(self, event):

--- a/kegbot/pycore/manager.py
+++ b/kegbot/pycore/manager.py
@@ -284,10 +284,7 @@ class FlowManager(Manager):
   def _PublishRelayEvent(self, flow, enable=True):
     self._logger.debug('Publishing relay event: flow=%s, enable=%s' % (flow,
         enable))
-			
-    client = kegnet.KegnetClient()
-    client.SendUserAuthenticated(flow.GetUsername())
-		
+				
     tap = self._tap_manager.GetTap(flow.GetMeterName())
     if not tap:
       # Unknown meter; don't attempt to enable any relays for it
@@ -560,15 +557,20 @@ class AuthenticationManager(Manager):
       username = token.get('username')
     except kbapi.NotFoundError:
       pass
+	  
+    client = kegnet.KegnetClient()  
 
     if not username:
+      client.SendUserAuthenticated('')
       self._logger.info('Token not assigned: %s' % record)
       return
 
     if not token.enabled:
+      client.SendUserAuthenticated('')
       self._logger.info('Token disabled: %s' % record)
       return
 
+    client.SendUserAuthenticated(username)  
     max_idle = common_defs.AUTH_DEVICE_MAX_IDLE_SECS.get(record.auth_device)
     if max_idle is None:
       max_idle = common_defs.AUTH_DEVICE_MAX_IDLE_SECS['default']


### PR DESCRIPTION
Previous updates broke the ability for Kegbot to activate relays connected to the Arduino/Kegboard. This fixes that issue by updating the listener on the Kegboard Daemon and publishing a different event from the Manager App.